### PR TITLE
Add sticky notes example

### DIFF
--- a/examples/sticky_notes/agents.py
+++ b/examples/sticky_notes/agents.py
@@ -2,13 +2,21 @@ from __future__ import annotations
 
 import datetime as dt
 import uuid
-from typing import Any
+import re
+from typing import Any, Iterable
 
 from pydantic import BaseModel
 
 from agents import Agent, function_tool, handoff, trace, Runner
 
-from .database import insert_input, insert_task, insert_note, search, init_db, DB_PATH
+from .database import (
+    insert_input,
+    insert_task,
+    insert_note,
+    search,
+    init_db,
+    DB_PATH,
+)
 
 
 class InputContext(BaseModel):
@@ -26,9 +34,13 @@ class ParsedInput(BaseModel):
     query_description: str | None = None
     topics: list[str] = []
     keywords: list[str] = []
+    numbers: list[int] = []
+    names: list[str] = []
+    dates: list[str] = []
 
 
 # --- Tool implementations ---------------------------------------------------
+
 
 @function_tool
 def simple_parse(text: str) -> ParsedInput:
@@ -38,26 +50,43 @@ def simple_parse(text: str) -> ParsedInput:
     parsed.is_task = "todo" in lowered or "task" in lowered
     parsed.is_note = "note" in lowered
     parsed.is_query = "?" in text
+
     if parsed.is_task:
         parsed.task_description = text
     if parsed.is_note:
         parsed.note_content = text
     if parsed.is_query:
         parsed.query_description = text.strip()
+
+    parsed.numbers = [int(n) for n in re.findall(r"\b\d+\b", text)]
+    parsed.names = re.findall(r"\b[A-Z][a-z]+\b", text)
+    parsed.dates = re.findall(r"\b\d{4}-\d{2}-\d{2}\b", text)
+    parsed.keywords = [w for w in re.findall(r"\b\w+\b", text.lower()) if len(w) > 3]
     return parsed
+
+
+@function_tool
+def ensure_valid(parsed: ParsedInput) -> None:
+    """Validate that the parsed input has at least one type set."""
+    if not (parsed.is_task or parsed.is_note or parsed.is_query):
+        raise ValueError("Input must be a task, note, or query")
 
 
 @function_tool
 def create_task_tool(context: InputContext, parsed: ParsedInput) -> str:
     """Store a task in the database."""
     task_id = f"task-{uuid.uuid4().hex[:8]}"
+    desc = parsed.task_description or ""
+    title = " ".join(desc.split()[:5])
+    priority = "high" if "high" in desc.lower() else None
+    due_date = parsed.dates[0] if parsed.dates else None
     insert_task(
         task_id,
         context.input_id,
-        parsed.task_description or "",
-        parsed.task_description or "",
-        None,
-        None,
+        title,
+        desc,
+        priority,
+        due_date,
         None,
     )
     return task_id
@@ -67,12 +96,14 @@ def create_task_tool(context: InputContext, parsed: ParsedInput) -> str:
 def create_note_tool(context: InputContext, parsed: ParsedInput, task_id: str | None = None) -> str:
     """Store a note in the database."""
     note_id = f"note-{uuid.uuid4().hex[:8]}"
+    content = parsed.note_content or ""
+    summary = " ".join(content.split()[:20])
     insert_note(
         note_id,
         context.input_id,
         task_id,
-        parsed.note_content or "",
-        (parsed.note_content or "").strip(),
+        content,
+        summary,
     )
     return note_id
 
@@ -82,7 +113,7 @@ def create_note_tool(context: InputContext, parsed: ParsedInput, task_id: str | 
 parse_agent = Agent[InputContext](
     name="parser",
     instructions="You parse user input into structured data.",
-    tools=[simple_parse],
+    tools=[simple_parse, ensure_valid],
     output_type=ParsedInput,
 )
 
@@ -108,26 +139,36 @@ action_agent = Agent[InputContext](
 
 async def process_text(text: str) -> None:
     init_db()
-    input_id = uuid.uuid4().hex[:8]
-    timestamp = dt.datetime.utcnow().isoformat()
-    insert_input(input_id, timestamp, text)
-    context = InputContext(input_id=input_id, timestamp=timestamp, text=text)
+    for segment in [part.strip() for part in text.split(";") if part.strip()]:
+        input_id = uuid.uuid4().hex[:8]
+        timestamp = dt.datetime.utcnow().isoformat()
+        insert_input(input_id, timestamp, segment)
+        context = InputContext(input_id=input_id, timestamp=timestamp, text=segment)
 
-    with trace("workflow"):
-        parse_result = await Runner.run(parse_agent, text, context=context)
-        parsed = parse_result.final_output_as(ParsedInput)
-        if parsed.is_query and parsed.query_description:
-            results = await run_query_agent(context, parsed.query_description)
-            print("Query results:", results)
-        if parsed.is_task:
-            task_id = await Runner.run(action_agent, {
-                "name": "create_task_tool",
-                "arguments": {"context": context, "parsed": parsed},
-            }, context=context)
-            print("Created task", task_id.final_output)
-        if parsed.is_note:
-            note_id = await Runner.run(action_agent, {
-                "name": "create_note_tool",
-                "arguments": {"context": context, "parsed": parsed},
-            }, context=context)
-            print("Created note", note_id.final_output)
+        with trace("workflow"):
+            parse_result = await Runner.run(parse_agent, segment, context=context)
+            parsed = parse_result.final_output_as(ParsedInput)
+
+            if parsed.is_query and parsed.query_description:
+                results = await run_query_agent(context, parsed.query_description)
+                print("Query results:", results)
+            if parsed.is_task:
+                task_id = await Runner.run(
+                    action_agent,
+                    {
+                        "name": "create_task_tool",
+                        "arguments": {"context": context, "parsed": parsed},
+                    },
+                    context=context,
+                )
+                print("Created task", task_id.final_output)
+            if parsed.is_note:
+                note_id = await Runner.run(
+                    action_agent,
+                    {
+                        "name": "create_note_tool",
+                        "arguments": {"context": context, "parsed": parsed},
+                    },
+                    context=context,
+                )
+                print("Created note", note_id.final_output)

--- a/examples/sticky_notes/agents.py
+++ b/examples/sticky_notes/agents.py
@@ -1,0 +1,133 @@
+from __future__ import annotations
+
+import datetime as dt
+import uuid
+from typing import Any
+
+from pydantic import BaseModel
+
+from agents import Agent, function_tool, handoff, trace, Runner
+
+from .database import insert_input, insert_task, insert_note, search, init_db, DB_PATH
+
+
+class InputContext(BaseModel):
+    input_id: str
+    timestamp: str
+    text: str
+
+
+class ParsedInput(BaseModel):
+    is_task: bool = False
+    is_note: bool = False
+    is_query: bool = False
+    task_description: str | None = None
+    note_content: str | None = None
+    query_description: str | None = None
+    topics: list[str] = []
+    keywords: list[str] = []
+
+
+# --- Tool implementations ---------------------------------------------------
+
+@function_tool
+def simple_parse(text: str) -> ParsedInput:
+    """Parse the raw text into a structured format."""
+    lowered = text.lower()
+    parsed = ParsedInput()
+    parsed.is_task = "todo" in lowered or "task" in lowered
+    parsed.is_note = "note" in lowered
+    parsed.is_query = "?" in text
+    if parsed.is_task:
+        parsed.task_description = text
+    if parsed.is_note:
+        parsed.note_content = text
+    if parsed.is_query:
+        parsed.query_description = text.strip()
+    return parsed
+
+
+@function_tool
+def create_task_tool(context: InputContext, parsed: ParsedInput) -> str:
+    """Store a task in the database."""
+    task_id = f"task-{uuid.uuid4().hex[:8]}"
+    insert_task(
+        task_id,
+        context.input_id,
+        parsed.task_description or "",
+        parsed.task_description or "",
+        None,
+        None,
+        None,
+    )
+    return task_id
+
+
+@function_tool
+def create_note_tool(context: InputContext, parsed: ParsedInput, task_id: str | None = None) -> str:
+    """Store a note in the database."""
+    note_id = f"note-{uuid.uuid4().hex[:8]}"
+    insert_note(
+        note_id,
+        context.input_id,
+        task_id,
+        parsed.note_content or "",
+        (parsed.note_content or "").strip(),
+    )
+    return note_id
+
+
+# --- Agents -----------------------------------------------------------------
+
+parse_agent = Agent[InputContext](
+    name="parser",
+    instructions="You parse user input into structured data.",
+    tools=[simple_parse],
+    output_type=ParsedInput,
+)
+
+query_agent = Agent[InputContext](
+    name="query",
+    instructions="Search existing tasks and notes.",
+    tools=[],
+    output_type=list[str],
+)
+
+
+async def run_query_agent(context: InputContext, query: str) -> list[str]:
+    with trace("query"):
+        return search(DB_PATH, query)
+
+
+action_agent = Agent[InputContext](
+    name="action",
+    instructions="Create tasks or notes based on parsed input.",
+    tools=[create_task_tool, create_note_tool],
+)
+
+
+async def process_text(text: str) -> None:
+    init_db()
+    input_id = uuid.uuid4().hex[:8]
+    timestamp = dt.datetime.utcnow().isoformat()
+    insert_input(input_id, timestamp, text)
+    context = InputContext(input_id=input_id, timestamp=timestamp, text=text)
+
+    with trace("workflow"):
+        parse_result = await Runner.run(parse_agent, text, context=context)
+        parsed = parse_result.final_output_as(ParsedInput)
+        if parsed.is_query and parsed.query_description:
+            results = await run_query_agent(context, parsed.query_description)
+            print("Query results:", results)
+        if parsed.is_task:
+            task_id = await Runner.run(action_agent, {
+                "name": "create_task_tool",
+                "arguments": {"context": context, "parsed": parsed},
+            }, context=context)
+            print("Created task", task_id.final_output)
+        if parsed.is_note:
+            note_id = await Runner.run(action_agent, {
+                "name": "create_note_tool",
+                "arguments": {"context": context, "parsed": parsed},
+            }, context=context)
+            print("Created note", note_id.final_output)

--- a/examples/sticky_notes/database.py
+++ b/examples/sticky_notes/database.py
@@ -50,6 +50,7 @@ def init_db(path: Path = DB_PATH) -> None:
 
 
 def execute(path: Path, query: str, params: Iterable) -> None:
+    """Execute a parameterized statement and commit the result."""
     conn = sqlite3.connect(path)
     cur = conn.cursor()
     cur.execute(query, params)
@@ -58,7 +59,10 @@ def execute(path: Path, query: str, params: Iterable) -> None:
 
 
 def insert_input(input_id: str, timestamp: str, text: str, path: Path = DB_PATH) -> None:
-    execute(path, "INSERT INTO inputs(id, timestamp, text) VALUES(?, ?, ?)", (input_id, timestamp, text))
+    """Insert the raw input entry."""
+    execute(
+        path, "INSERT INTO inputs(id, timestamp, text) VALUES(?, ?, ?)", (input_id, timestamp, text)
+    )
 
 
 def insert_task(
@@ -71,6 +75,7 @@ def insert_task(
     notes: str | None,
     path: Path = DB_PATH,
 ) -> None:
+    """Insert a task entry."""
     execute(
         path,
         "INSERT INTO tasks(id, input_id, title, description, priority, due_date, notes) VALUES(?, ?, ?, ?, ?, ?, ?)",
@@ -86,6 +91,7 @@ def insert_note(
     summary: str,
     path: Path = DB_PATH,
 ) -> None:
+    """Insert a note entry."""
     execute(
         path,
         "INSERT INTO notes(id, input_id, task_id, content, summary) VALUES(?, ?, ?, ?, ?)",
@@ -94,6 +100,7 @@ def insert_note(
 
 
 def search(path: Path, query: str) -> list[str]:
+    """Return tasks or notes matching the query."""
     conn = sqlite3.connect(path)
     cur = conn.cursor()
     pattern = f"%{query}%"

--- a/examples/sticky_notes/database.py
+++ b/examples/sticky_notes/database.py
@@ -1,0 +1,111 @@
+import sqlite3
+from pathlib import Path
+from typing import Iterable
+
+DB_PATH = Path(__file__).with_suffix(".db")
+
+
+def init_db(path: Path = DB_PATH) -> None:
+    """Create the database tables if they do not exist."""
+    conn = sqlite3.connect(path)
+    cur = conn.cursor()
+    cur.execute(
+        """
+        CREATE TABLE IF NOT EXISTS inputs (
+            id TEXT PRIMARY KEY,
+            timestamp TEXT NOT NULL,
+            text TEXT NOT NULL
+        )
+        """
+    )
+    cur.execute(
+        """
+        CREATE TABLE IF NOT EXISTS tasks (
+            id TEXT PRIMARY KEY,
+            input_id TEXT NOT NULL,
+            title TEXT,
+            description TEXT,
+            priority TEXT,
+            due_date TEXT,
+            notes TEXT,
+            FOREIGN KEY(input_id) REFERENCES inputs(id)
+        )
+        """
+    )
+    cur.execute(
+        """
+        CREATE TABLE IF NOT EXISTS notes (
+            id TEXT PRIMARY KEY,
+            input_id TEXT NOT NULL,
+            task_id TEXT,
+            content TEXT,
+            summary TEXT,
+            FOREIGN KEY(input_id) REFERENCES inputs(id),
+            FOREIGN KEY(task_id) REFERENCES tasks(id)
+        )
+        """
+    )
+    conn.commit()
+    conn.close()
+
+
+def execute(path: Path, query: str, params: Iterable) -> None:
+    conn = sqlite3.connect(path)
+    cur = conn.cursor()
+    cur.execute(query, params)
+    conn.commit()
+    conn.close()
+
+
+def insert_input(input_id: str, timestamp: str, text: str, path: Path = DB_PATH) -> None:
+    execute(path, "INSERT INTO inputs(id, timestamp, text) VALUES(?, ?, ?)", (input_id, timestamp, text))
+
+
+def insert_task(
+    task_id: str,
+    input_id: str,
+    title: str,
+    description: str,
+    priority: str | None,
+    due_date: str | None,
+    notes: str | None,
+    path: Path = DB_PATH,
+) -> None:
+    execute(
+        path,
+        "INSERT INTO tasks(id, input_id, title, description, priority, due_date, notes) VALUES(?, ?, ?, ?, ?, ?, ?)",
+        (task_id, input_id, title, description, priority, due_date, notes),
+    )
+
+
+def insert_note(
+    note_id: str,
+    input_id: str,
+    task_id: str | None,
+    content: str,
+    summary: str,
+    path: Path = DB_PATH,
+) -> None:
+    execute(
+        path,
+        "INSERT INTO notes(id, input_id, task_id, content, summary) VALUES(?, ?, ?, ?, ?)",
+        (note_id, input_id, task_id, content, summary),
+    )
+
+
+def search(path: Path, query: str) -> list[str]:
+    conn = sqlite3.connect(path)
+    cur = conn.cursor()
+    pattern = f"%{query}%"
+    cur.execute(
+        "SELECT title FROM tasks WHERE title LIKE ? OR description LIKE ? ORDER BY rowid DESC LIMIT 10",
+        (pattern, pattern),
+    )
+    task_results = [row[0] for row in cur.fetchall()]
+    cur.execute(
+        "SELECT content FROM notes WHERE content LIKE ? ORDER BY rowid DESC LIMIT 10",
+        (pattern,),
+    )
+    note_results = [row[0] for row in cur.fetchall()]
+    conn.close()
+    return task_results + note_results

--- a/examples/sticky_notes/main.py
+++ b/examples/sticky_notes/main.py
@@ -1,0 +1,12 @@
+import asyncio
+
+from .agents import process_text
+
+
+async def main() -> None:
+    text = input("Enter text: ")
+    await process_text(text)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/tests/sticky_notes/test_database.py
+++ b/tests/sticky_notes/test_database.py
@@ -1,6 +1,13 @@
 from pathlib import Path
 
-from examples.sticky_notes.database import init_db, insert_input, search, DB_PATH
+from examples.sticky_notes.database import (
+    init_db,
+    insert_input,
+    insert_task,
+    insert_note,
+    search,
+    DB_PATH,
+)
 
 
 def test_db_insert_and_search(tmp_path: Path) -> None:
@@ -9,3 +16,12 @@ def test_db_insert_and_search(tmp_path: Path) -> None:
     insert_input("id1", "now", "test task", db)
     results = search(db, "test")
     assert results
+
+
+def test_insert_task_and_note(tmp_path: Path) -> None:
+    db = tmp_path / "test.db"
+    init_db(db)
+    insert_task("t1", "in1", "demo", "demo description", None, None, None, db)
+    insert_note("n1", "in1", "t1", "content", "summary", db)
+    results = search(db, "demo")
+    assert "demo" in results[0]

--- a/tests/sticky_notes/test_database.py
+++ b/tests/sticky_notes/test_database.py
@@ -1,0 +1,11 @@
+from pathlib import Path
+
+from examples.sticky_notes.database import init_db, insert_input, search, DB_PATH
+
+
+def test_db_insert_and_search(tmp_path: Path) -> None:
+    db = tmp_path / "test.db"
+    init_db(db)
+    insert_input("id1", "now", "test task", db)
+    results = search(db, "test")
+    assert results

--- a/tests/sticky_notes/test_parsing.py
+++ b/tests/sticky_notes/test_parsing.py
@@ -1,0 +1,7 @@
+from examples.sticky_notes.agents import simple_parse
+
+
+def test_simple_parse() -> None:
+    parsed = simple_parse("TODO finish project by 2025-12-31")
+    assert parsed.is_task
+    assert parsed.dates == ["2025-12-31"]


### PR DESCRIPTION
## Summary
- add sticky notes example with simple database helpers
- implement parsing and action agents
- provide basic CLI entrypoint
- test database insert and search

## Testing
- `make format` *(fails: Failed to download certifi)*
- `make lint` *(fails: Failed to download mypy)*
- `make mypy` *(fails: Failed to download python-xlib)*
- `make tests` *(fails: Failed to download pynput)*

------
https://chatgpt.com/codex/tasks/task_e_6854b38b69fc832392f99ac21058edac